### PR TITLE
Support making AppX packages directly

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "cookie-parser": "~1.3.4",
     "debug": "~2.1.1",
     "express": "~4.12.2",
+    "fs-extra": "^2.0.0",
     "imagesize": "^1.0.0",
     "jade": "~1.9.2",
     "lodash": "^3.6.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "cookie-parser": "~1.3.4",
     "debug": "~2.1.1",
     "express": "~4.12.2",
-    "fs-extra": "^2.0.0",
+    "fs-extra": "2.0.0",
     "imagesize": "^1.0.0",
     "jade": "~1.9.2",
     "lodash": "^3.6.0",

--- a/src/controllers/manifests.js
+++ b/src/controllers/manifests.js
@@ -179,8 +179,11 @@ exports.create = function(client, storage, pwabuilder, raygun){
             return Q.nfcall(fs.writeFile, projectDirectory + "\\Store packages\\windows10\\test_install.ps1", str);
           })
           .then(function(err) {
+            // Remove existing package readme so that we can call our new 'readme' whatever we want below.
+            return Q.nfcall(fs.remove, projectDirectory + "\\Store packages\\windows10\\Windows10-next-steps.md");
+          })
+          .then(function(err) {
             // Copy Readme File into project directory
-            // TODO: Do we want to delete/modify/overwrite the Windows 10 Next Steps file with this one?
             return Q.nfcall(fs.copy, "src\\controllers\\readme.md", projectDirectory + "\\Store packages\\windows10\\readme.md");
           })
           .then(function(err) {
@@ -188,7 +191,7 @@ exports.create = function(client, storage, pwabuilder, raygun){
             return pwa10.package(projectDirectory, { DotWeb: false, AutoPublish: false, Sign: false }); 
           })
           .then(function(){ return storage.setPermissions(output); })
-          // TODO: Grab inner sub-directory to zip (so will contain 'windows10' folder)?
+          // TODO: In the future, grab inner sub-directory to zip (so will contain 'windows10' folder)?
           .then(function(){ 
             return storage.createZip(output, manifest.content.short_name); 
           })

--- a/src/controllers/readme.md
+++ b/src/controllers/readme.md
@@ -1,0 +1,18 @@
+PWA Builder Generated AppX
+==========================
+
+Thanks for generating your AppX with [PWA Builder](https://www.pwabuilder.com).
+
+If you run the `test_install.ps1` PowerShell script on your machine, you'll be able to test your app before submitting it to the store.
+
+Testing
+-------
+
+TODO...
+
+Submitting to the Store
+-----------------------
+
+Visit the [Dev Center](https://developer.microsoft.com) to submit your app.
+
+TODO...

--- a/src/controllers/test_install.ps1
+++ b/src/controllers/test_install.ps1
@@ -1,0 +1,34 @@
+$key = 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\AppModelUnlock'
+$isDeveloperMode = (Get-ItemProperty -Path $key -Name AllowDevelopmentWithoutDevLicense).AllowDevelopmentWithoutDevLicense
+
+if($isDeveloperMode)
+{
+    $guid = 'INSERT-YOUR-PACKAGE-IDENTITY-NAME-HERE'
+    $appxmanifest = 'manifest\AppxManifest.xml'
+
+    if(Test-Path $appxmanifest) {
+        try {
+            $installed = Get-AppxPackage $guid
+            Clear-Host
+
+            if($installed) {
+                Remove-AppxPackage $installed.PackageFullName
+            }
+
+            Add-AppxPackage -Register $appxmanifest
+
+            Write-Host "App installed. You can find the app Installed in your start menu."
+        } catch {
+            $ErrorMessage = $_.Exception.Message
+            Write-Host "Error: " + $ErrorMessage
+        }
+    } else {
+        Write-Host "Missing AppxManifest.xml"
+    }
+}
+else {
+    Write-Host "Error: The App was not installed.  It is likely because your computer needs to be in developer mode to install this test app. Please change your system to developer mode and run this script again."
+}
+
+Write-Host "Press any key to continue ..."
+$host.UI.RawUI.ReadKey("NoEcho,IncludeKeyDown")

--- a/src/routes/manifests.js
+++ b/src/routes/manifests.js
@@ -14,6 +14,7 @@ module.exports = function(client,azure,pwabuilderLib){
         .get('/:id',controller.show)
         .post('/',controller.create)
         .put('/:id',controller.update)
+        .post('/:id/appx',controller.appx)
         .post('/:id/build',controller.build)
         .post('/:id/package', controller.package)
         .post('/:id/generatemissingimages', controller.generateMissingImages);


### PR DESCRIPTION
This change is to allow the site to request a fully built AppX package to provide to the client.  It requires the Package Identity Publisher Name and Id, Package Name, and Version Number.

Adds a dependency on `fs-extra` for easier file copy.

Remaining Discussion Points

- [ ] Contents of Readme.md
    - [x] Does this overwrite the `Windows10-next-steps.md` file instead => yes.

Postponed:
~~Do we want to shorten zip file's folder structure~~