### PR TITLE
Update/Add MacOS & Android native platforms

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "pwabuilder-lib": "^2.0.3-RC.0",
     "pwabuilder-cordova": "^2.0.0-rc",
     "pwabuilder-android": "^2.0.0-rc",
+    "pwabuilder-macos": "^0.3.0",
     "pwabuilder-web": "^2.0.0-rc",
     "pwabuilder-windows10": "^2.0.3-rc.1",
     "morgan": "~1.5.1",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "loglevel": "^1.2.0",
     "pwabuilder-lib": "^2.0.3-RC.0",
     "pwabuilder-cordova": "^2.0.0-rc",
+    "pwabuilder-android": "^2.0.0-rc",
     "pwabuilder-web": "^2.0.0-rc",
     "pwabuilder-windows10": "^2.0.3-rc.1",
     "morgan": "~1.5.1",

--- a/platforms.json
+++ b/platforms.json
@@ -4,8 +4,12 @@
         "source": "pwabuilder-windows10"
     },
     "android": {
-        "packageName": "pwabuilder-cordova",
-        "source": "pwabuilder-cordova"
+        "packageName": "pwabuilder-android",
+        "source": "pwabuilder-android"
+    },
+    "mac": {
+        "packageName": "pwabuilder-mac",
+        "source": "pwabuilder-mac"
     },
     "ios": {
         "packageName": "pwabuilder-cordova",

--- a/platforms.json
+++ b/platforms.json
@@ -8,8 +8,8 @@
         "source": "pwabuilder-android"
     },
     "mac": {
-        "packageName": "pwabuilder-mac",
-        "source": "pwabuilder-mac"
+        "packageName": "pwabuilder-macos",
+        "source": "pwabuilder-macos"
     },
     "ios": {
         "packageName": "pwabuilder-cordova",


### PR DESCRIPTION
In this PR we:

- Update the Android platform version with their native one.

- Add MacOs native platform to manifold-api

- Add pwabuilder-android module in package.json