### PR TITLE
Replace "mac" with "MacOS" platform name inside platforms declaration.

### DIFF
--- a/platforms.json
+++ b/platforms.json
@@ -11,6 +11,10 @@
         "packageName": "pwabuilder-cordova",
         "source": "pwabuilder-cordova"
     },
+    "MacOS": {
+        "packageName": "pwabuilder-macos",
+        "source": "pwabuilder-macos"
+    },
     "windows": {
         "packageName": "pwabuilder-cordova",
         "source": "pwabuilder-cordova"


### PR DESCRIPTION
The MacOs download button was sending empty packages because it could not find the "MacOS" platform. This platform exists, but it was declared with the "mac" name. So, I changed the name of the platform to MacOS within the platform declaration (platforms.json) and the package was published correctly

![image](https://user-images.githubusercontent.com/3893598/47791389-5ae8b380-dcf8-11e8-9306-3f82b3fc68a0.png)


![image](https://user-images.githubusercontent.com/3893598/47790913-26c0c300-dcf7-11e8-9f95-b288ed6a5e5a.png)

 