### PR TITLE
Replace "_.any" with "_.some" function name inside pwabuilder.js

### DIFF
--- a/src/services/pwabuilder.js
+++ b/src/services/pwabuilder.js
@@ -236,7 +236,7 @@ PWABuilder.prototype.assignValidationErrors = function(errors,manifest){
   var data = { errors: []};
 
   _.each(errors,function(e){
-    if(_.any(data.errors,'member',e.member)){
+    if(_.some(data.errors,'member',e.member)){
       var error = _.find(data.errors,'member',e.member);
       error.issues = error.issues || [];
       error.issues.push({ description: e.description, platform: e.platform, code: e.code });
@@ -259,7 +259,7 @@ PWABuilder.prototype.assignSuggestions = function(suggestions,manifest){
   var data = { suggestions: []};
 
   _.each(suggestions,function(s){
-    if(_.any(data.suggestions,'member',s.member)){
+    if(_.some(data.suggestions,'member',s.member)){
       var suggestion = _.find(data.suggestions,'member',s.member);
       suggestion.issues = suggestion.issues || [];
       suggestion.issues.push({ description: s.description, platform: s.platform, code: s.code });
@@ -282,7 +282,7 @@ PWABuilder.prototype.assignWarnings = function(warnings,manifest){
   var data = { warnings: []};
 
   _.each(warnings,function(w){
-    if(_.any(data.warnings,'member',w.member)){
+    if(_.some(data.warnings,'member',w.member)){
       var warning = _.find(data.warnings,'member',w.member);
       warning.issues = warning.issues || [];
       warning.issues.push({ description: w.description, platform: w.platform, code: w.code });


### PR DESCRIPTION
The Lodash _.any function was deprecated on the latest version. I replaced the _.any function name with its new function name [_.some](https://lodash.com/docs/3.10.1#some) in all of its occurrences inside _pwabuilder.js_ . The _.any function will be no longer used on further versions.
